### PR TITLE
Show terms where the "See also" has a count

### DIFF
--- a/lib/authority_browse/names.rb
+++ b/lib/authority_browse/names.rb
@@ -78,7 +78,8 @@ module AuthorityBrowse
       def load_solr_with_matched(solr_uploader = AuthorityBrowse::Solr::Uploader.new(collection: "authority_browse_reindex"))
         write_and_send_docs(solr_uploader) do |out, milemarker|
           AuthorityBrowse.db.fetch(get_matched_query).stream.chunk_while { |bef, aft| aft[:id] == bef[:id] }.each do |ary|
-            out.puts AuthorityBrowse::SolrDocument::Names::AuthorityGraphSolrDocument.new(ary).to_solr_doc
+            document = AuthorityBrowse::SolrDocument::Names::AuthorityGraphSolrDocument.new(ary)
+            out.puts document.to_solr_doc if document.any?
             milemarker.increment_and_log_batch_line
           end
         end
@@ -130,7 +131,6 @@ module AuthorityBrowse
           ON names.id = nsa.name_id 
           LEFT JOIN names AS names2 
           ON nsa.see_also_id = names2.id 
-          WHERE names.count > 0
         SQL
       end
 

--- a/lib/authority_browse/names.rb
+++ b/lib/authority_browse/names.rb
@@ -129,7 +129,7 @@ module AuthorityBrowse
           FROM names 
           LEFT OUTER JOIN names_see_also AS nsa 
           ON names.id = nsa.name_id 
-          LEFT JOIN names AS names2 
+          LEFT OUTER JOIN names AS names2 
           ON nsa.see_also_id = names2.id 
         SQL
       end

--- a/lib/authority_browse/solr_document/names.rb
+++ b/lib/authority_browse/solr_document/names.rb
@@ -44,6 +44,10 @@ module AuthorityBrowse
           @first = @data.first
         end
 
+        def any?
+          count > 0 || @data.any? { |x| !x[:see_also_count].nil? && x[:see_also_count] > 0 }
+        end
+
         def match_text
           @first[:match_text]
         end

--- a/spec/authority_browse/solr_document/names_spec.rb
+++ b/spec/authority_browse/solr_document/names_spec.rb
@@ -35,6 +35,34 @@ RSpec.describe AuthorityBrowse::SolrDocument::Names::AuthorityGraphSolrDocument 
   subject do
     described_class.new(@name)
   end
+  context "#any?" do
+    it "is true if the main item has a count and the see also all have counts" do
+      expect(subject.any?).to eq(true)
+    end
+
+    it "is true if the main item does not have a count but at least one see also does" do
+      3.times { |x| @name[x][:count] = 0 }
+      expect(subject.any?).to eq(true)
+    end
+    it "is true if the main item has a count but none of the see also have a count" do
+      3.times { |x| @name[x][:see_also_count] = 0 }
+      expect(subject.any?).to eq(true)
+    end
+    it "is false if all see also counts and the main count are zero" do
+      3.times do |x|
+        @name[x][:count] = 0
+        @name[x][:see_also_count] = 0
+      end
+      expect(subject.any?).to eq(false)
+    end
+    it "is false if main count is zero and all see also counts are nil" do
+      3.times do |x|
+        @name[x][:count] = 0
+        @name[x][:see_also_count] = nil
+      end
+      expect(subject.any?).to eq(false)
+    end
+  end
   context "#id" do
     it "returns a normalized version fo the name with a unicode space and string name" do
       expect(subject.id).to eq("twain mark 1835 1910\u001fname")


### PR DESCRIPTION
changes how the matched terms work by showing items whose count is 0 but who have a see also that is greater than 0. 

Example documents:
```
[
{
        "id":"snodgrass quintus curtius 1835 1910\u001fname",
        "loc_id":"http://id.loc.gov/authorities/names/n93099461",
        "browse_field":"name",
        "term":"Snodgrass, Quintus Curtius, 1835-1910",
        "see_also":["Twain, Mark, 1835-1910||1528"],
        "count":0,
        "date_of_index":"2023-11-27T00:00:00Z",
        "_version_":1783757239722442761},
{
        "id":"twain mark 1835 1910\u001fname",
        "loc_id":"http://id.loc.gov/authorities/names/n79021164",
        "browse_field":"name",
        "term":"Twain, Mark, 1835-1910",
        "see_also":["Clemens, Samuel Langhorne, 1835-1910||33",
          "Conte, Louis de, 1835-1910||2"],
        "count":1528,
        "date_of_index":"2023-11-27T00:00:00Z",
        "_version_":1783757205618556931}
]