### PR TITLE
Change to solr_cloud 0.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "canister"
 gem "rubyzip"
 gem "semantic_logger"
 gem "thor"
-gem "solr_cloud-connection", ">= 0.3.0"
+gem "solr_cloud-connection", ">= 0.4.0"
 
 gem "sqlite3", "~> 1.4", platforms: :mri
 gem "jdbc-sqlite3", "~> 3.28", platforms: :jruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    solr_cloud-connection (0.3.0)
+    solr_cloud-connection (0.4.0)
       faraday (~> 2.7.12)
       httpx (~> 1.1.5)
       rubyzip (~> 2.3.0)
@@ -142,7 +142,7 @@ DEPENDENCIES
   semantic_logger
   sequel (~> 5.60)
   simplecov
-  solr_cloud-connection (>= 0.3.0)
+  solr_cloud-connection (>= 0.4.0)
   sqlite3 (~> 1.4)
   standardrb
   thor

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ if ENV["GHA_TEST"] == "true"
 end
 
 # S.register(:git_tag) { "my.test.tag" }
-S.register(:git_tag) { "version" }
+S.register(:git_tag) { "1.0.0" }
 S.register(:today) { "2099-12-01-00-00-00" }
 S.register(:min_authority_browse_record_count) { 0 }
 


### PR DESCRIPTION
No change except to the Gemfile[.lock]. 0.4.0 has the correct rules for verifying illegal names.