### PR TITLE
adds project_root to Services; changes to use wget to fetch skos files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ coverage/
 .byebug_history
 .byebug_save
 .irb_history
+.wget-hsts
 authority_browse.zip
 reports/
 *.db

--- a/.irbrc
+++ b/.irbrc
@@ -1,2 +1,2 @@
-$LOAD_PATH.unshift("/app/lib")
+$LOAD_PATH.unshift(File.absolute_path(File.join(__dir__, "lib")))
 require "browse"

--- a/lib/authority_browse/base.rb
+++ b/lib/authority_browse/base.rb
@@ -67,19 +67,7 @@ module AuthorityBrowse
       #
       # @param url [String] [location skos file for names]
       def fetch_skos_file(remote_file: remote_skos_file, local_file: local_skos_file)
-        conn = Faraday.new do |builder|
-          builder.use Faraday::Response::RaiseError
-          builder.response :follow_redirects
-          builder.adapter :httpx
-        end
-        File.open(local_file, "w") do |f|
-          resp = conn.get(remote_file) do |req|
-            req.options.on_data = proc do |chunk, _overall_received_bytes, _env|
-              f << chunk
-            end
-          end
-          puts resp
-        end
+        `wget -O #{local_file} #{remote_skos_file}`
       end
     end
   end

--- a/lib/authority_browse/names.rb
+++ b/lib/authority_browse/names.rb
@@ -131,7 +131,7 @@ module AuthorityBrowse
       #
       # @return [String]
       def local_skos_file
-        "tmp/names.skosrdf.jsonld.gz"
+        File.join(S.project_root, "tmp/names.skosrdf.jsonld.gz")
       end
 
       # @return [Symbol]

--- a/lib/authority_browse/subjects.rb
+++ b/lib/authority_browse/subjects.rb
@@ -120,7 +120,7 @@ module AuthorityBrowse
       #
       # @return [String]
       def local_skos_file
-        "tmp/subjects.skosrdf.jsonld.gz"
+        File.join(S.project_root, "tmp/subjects.skosrdf.jsonld.gz")
       end
 
       # @return [Symbol]

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -63,6 +63,10 @@ S.register(:git_tag) do
   tag
 end
 
+S.register(:project_root) do
+  File.absolute_path(File.join(__dir__, ".."))
+end
+
 # Path to file for dumping generated solr docs before uploading to solr
 S.register(:solr_docs_file) { "tmp/solr_docs.jsonl.gz" }
 


### PR DESCRIPTION
Adds `S.project_root` to make it easier to know where the root directory is
Changes from using Faraday to fetch the skos files to shelling out to `wget` because with Faraday I was getting a bloated corrupted file. 