### PR TITLE
Fix concurrency Bug

### DIFF
--- a/lib/authority_browse/term_fetcher.rb
+++ b/lib/authority_browse/term_fetcher.rb
@@ -84,14 +84,14 @@ module AuthorityBrowse
       end
     end
 
-    # @retrun Concurrent::ThreadPoolExecutor
+    # @retrun Concurrent::FixedThreadPool
     def pool
-      @pool ||= Concurrent::ThreadPoolExecutor.new(
-        min_threads: @threads,
-        max_threads: @threads,
-        max_queue: 200,
-        fallback_policy: :caller_runs
-      )
+      @pool ||= Concurrent::FixedThreadPool.new(@threads,
+        # max_queue: 0 means unlimited items in the queue. This is so we don't lose any
+        # work when shutting down.
+        max_queue: 0,
+        # fallback_policy is probably unnessary here but it won't hurt to set is explictly
+        fallback_policy: :caller_runs)
     end
 
     # Fetch all of the facets and load them into the :_from_biblio table

--- a/lib/call_number_browse/term_fetcher.rb
+++ b/lib/call_number_browse/term_fetcher.rb
@@ -8,7 +8,10 @@ module CallNumberBrowse
     # @return Concurrent::FixedThreadPool
     def pool
       @pool ||= Concurrent::FixedThreadPool.new(@threads,
-        max_queue: 200,
+        # max_queue: 0 means unlimited items in the queue. This is so we don't lose any
+        # work when shutting down.
+        max_queue: 0,
+        # fallback_policy is probably unnessary here but it won't hurt to set is explictly
         fallback_policy: :caller_runs)
     end
 


### PR DESCRIPTION
The term fetchers were not retrieving all of the terms from Solr because the thread queue was overloaded. The number of threads is bounded for these processes and it's important that all of the terms are collected, so this value is set to 0 which means infinity.

This PR also changes ThreadPoolExecutor to FixedThreadPool in authority_browse term_fetcher so that they match.