### PR TITLE
Update to ruby 3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ reports/
 *.db
 .solargraph.yml
 *.sql
+vendor/
 
 tmp/*
 !tmp/.keep

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2 AS development
+FROM ruby:3.3 AS development
 
 # Check https://rubygems.org/gems/bundler/versions for the latest version.
 ARG UNAME=app

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       faraday (~> 2.7.12)
       httpx (~> 1.1.5)
       rubyzip (~> 2.3.0)
-    sqlite3 (1.6.9-x86_64-linux)
+    sqlite3 (1.7.3-x86_64-linux)
     standard (1.32.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -189,4 +189,4 @@ DEPENDENCIES
   zinzout (~> 0.1)
 
 BUNDLED WITH
-   2.4.22
+   2.5.17


### PR DESCRIPTION
Updates the docker file to ruby 3.3. 

Adds vendor to `.gitignore` so that the update workflow doesn't try to add everything in the `vendor` directory.